### PR TITLE
Minor enhancements to KafkaQuery script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2020-06-01
+### Added
+- `--debug` flag to view debug logs
+- `--limit` parameters to specify maximum number of messages to consume, starting from the last
+
+### Changed
+- Default value of poll timeout to `5000` milliseconds from `1000`, to account for slow networks
+
 ## 2020-05-27
 ### Added
 - KafkaQuery - Ability to match against multiple values for a JSON path variable
@@ -9,7 +17,7 @@
 - KafkaPublisher - Throttling to not produce messages too fast so as to not run out of memory
 
 ### Changed
-- [Issue 4](https://github.com/devatherock/utilities/issues/4): Wrote consumed messages to file in a single thread to 
+- [Issue 4](https://github.com/devatherock/utilities/issues/4): Wrote consumed messages to file in a single thread to
 prevent messages from getting mixed up
 
 ## 2020-04-26


### PR DESCRIPTION
### Added
- `--debug` flag to view debug logs
- `--limit` parameters to specify maximum number of messages to consume, starting from the last

### Changed
- Default value of poll timeout to `5000` milliseconds from `1000`, to account for slow networks